### PR TITLE
Replaces oc set --from-file with oc create secret

### DIFF
--- a/scripts/global-pull-secret.sh
+++ b/scripts/global-pull-secret.sh
@@ -47,7 +47,7 @@ echo "Merging pull secrets"
 jq -s '.[0] * .[1]' "${GLOBAL_DIR}/.dockerconfigjson" "${ICR_DIR}/.dockerconfigjson" > "${RESULT_FILE}"
 
 RESULT_BASE64=$(base64 < "${RESULT_FILE}")
-PATCH="[{\"op\": \"replace\", \"path\": \"/data/.dockerconfigjson\", \"value\": \"${RESULT_BASE64}\"}]"
+echo "{}" | jq -c --arg VALUE "${RESULT_BASE64}" '[{op: "replace", path: "/data/.dockerconfigjson", value: $VALUE}]' > patch-pull-secret.json
 
 echo "Patching global pull secret"
-oc patch secret pull-secret -n openshift-config --type=json -p="${PATCH}"
+oc patch secret pull-secret -n openshift-config --type=json -p="$(cat patch-pull-secret.json)"

--- a/scripts/global-pull-secret.sh
+++ b/scripts/global-pull-secret.sh
@@ -48,4 +48,5 @@ jq -s '.[0] * .[1]' "${GLOBAL_DIR}/.dockerconfigjson" "${ICR_DIR}/.dockerconfigj
 
 
 echo "Updating global pull secret"
-oc set data secret/pull-secret -n openshift-config --from-file=".dockerconfigjson=${RESULT_FILE}"
+oc create secret generic pull-secret -n openshift-config --from-file=".dockerconfigjson=${RESULT_FILE}" --dry-run=client -o yaml | \
+  oc apply -f -


### PR DESCRIPTION
Older versions of the oc cli do not support `oc set ... --from-file`. Replace with more general `oc create secret ... --dry-run=client -o yaml | oc apply -f -`